### PR TITLE
Skip zero-value orders

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -103,6 +103,10 @@ class Engine:
         else:
             amount = 0
 
+        if not amount:
+            logger.warning("Skipping order for %s, computed amount is %s", symbol, amount)
+            return
+
         # CCXT expects 'buy' or 'sell'; map our signal sides accordingly
         order_side = "buy" if side == "long" else "sell"
 


### PR DESCRIPTION
## Summary
- add early exit for empty order amounts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687214e6940c8329b48d50aa8a8491de