### PR TITLE
Fix locking bug in Engine.send_order

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -148,8 +148,6 @@ class Engine:
             "order": order,
             "status": "open",
         })
-        # release the lock once order has been executed
-        self.instrument_lock.pop(symbol, None)
 
     def fetch_ohlcv(self, symbol: str, limit: int = 2000) -> pd.DataFrame:
         logger.info("Fetching OHLCV for %s", symbol)


### PR DESCRIPTION
## Summary
- remove `self.instrument_lock.pop()` from `_send_order`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872893d1af883299fcb4da30667f626