### PR TITLE
Implement consensus trading logic with trailing stop

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,3 +15,4 @@ strategies:
 fees: 0.0005  # 0.05%
 slippage: 0.0005
 position_size_pct: 0.01  # 1% capital
+delta_be: 0.0015  # 0.15% move to arm trailing stop


### PR DESCRIPTION
## Summary
- add `delta_be` threshold to config
- extend position loading to support trailing fields
- implement trailing stop updates via `_update_open_positions`
- open trades only when ≥3 strategies align and include a top3 strategy
- store stop price and ATR multiplier in positions

## Testing
- `python -m py_compile core/engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68713c98dbb08329b5b7d3ab624c4a77