### PR TITLE
Update MACDZeroCross conditions

### DIFF
--- a/strategies/macdzerocross.py
+++ b/strategies/macdzerocross.py
@@ -14,16 +14,29 @@ class MACDZeroCross(BaseStrategy):
     def generate_signal(cls, df: pd.DataFrame, extras: dict[str, pd.Series]):  # type: ignore
         if len(df) < 35:
             return Signal("flat")
-        _, _, hist = compute_macd(df["Close"])
-        prev = hist.iloc[-2]
-        curr = hist.iloc[-1]
+        macd, signal, hist = compute_macd(df["Close"])
+        prev_hist = hist.iloc[-2]
+        curr_hist = hist.iloc[-1]
+        curr_macd = macd.iloc[-1]
+        curr_signal = signal.iloc[-1]
+
         action = "flat"
-        if prev < 0 <= curr:
+        if (
+            prev_hist < 0 <= curr_hist
+            and curr_hist > prev_hist
+            and curr_macd > curr_signal
+        ):
             action = "long"
-        elif prev > 0 >= curr:
+        elif (
+            prev_hist > 0 >= curr_hist
+            and curr_hist < prev_hist
+            and curr_macd < curr_signal
+        ):
             action = "short"
+
         atr14 = extras.get("ATR_14")
         stop = None
         if atr14 is not None:
-            stop = float(atr14.iloc[-1])
+            stop = 2.0 * float(atr14.iloc[-1])
+
         return Signal(action, stop_distance=stop)

--- a/tests/test_macdzerocross.py
+++ b/tests/test_macdzerocross.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+import strategies.macdzerocross as macdzerocross
+
+
+def test_macdzerocross_long(monkeypatch):
+    df = pd.DataFrame({'Close': [1] * 35})
+
+    def fake_macd(series):
+        macd = pd.Series([0] * 33 + [0.3, 1.0])
+        signal = pd.Series([0] * 33 + [0.4, 0.8])
+        hist = macd - signal
+        return macd, signal, hist
+
+    monkeypatch.setattr(macdzerocross, "compute_macd", fake_macd)
+    extras = {"ATR_14": pd.Series([1] * 35)}
+    sig = macdzerocross.MACDZeroCross.generate_signal(df, extras)
+    assert sig.action == "long"
+    assert sig.stop_distance == 2.0
+
+
+def test_macdzerocross_short(monkeypatch):
+    df = pd.DataFrame({'Close': [1] * 35})
+
+    def fake_macd(series):
+        macd = pd.Series([0] * 33 + [1.0, 0.2])
+        signal = pd.Series([0] * 33 + [0.8, 0.5])
+        hist = macd - signal
+        return macd, signal, hist
+
+    monkeypatch.setattr(macdzerocross, "compute_macd", fake_macd)
+    extras = {"ATR_14": pd.Series([1] * 35)}
+    sig = macdzerocross.MACDZeroCross.generate_signal(df, extras)
+    assert sig.action == "short"
+    assert sig.stop_distance == 2.0


### PR DESCRIPTION
## Summary
- trigger MACDZeroCross only if histogram is rising above zero with macd over signal
- multiply stop distance by 2x ATR14
- add regression tests for MACDZeroCross

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d877f3e48329a1f95aa5e46c5725