### PR TITLE
Add SMA200 filter in Donchian strategy

### DIFF
--- a/strategies/donchian20.py
+++ b/strategies/donchian20.py
@@ -1,13 +1,14 @@
 """Donchian 20 Breakout strategy.
 
-Simplified MVP implementation: generates LONG when last close > 20-period high;
-SHORT when < 20-period low. Trailing stop distance = 2 * ATR20.
+Simplified MVP implementation: generates LONG when last close > 20-period high
+and above SMA200; SHORT when < 20-period low. Trailing stop distance =
+1.5 * ATR20.
 """
 from __future__ import annotations
 
 import pandas as pd
 
-from core.utils import Signal
+from core.utils import Signal, compute_sma
 from strategies.base import BaseStrategy
 
 
@@ -16,18 +17,23 @@ class Donchian20(BaseStrategy):
 
     @classmethod
     def generate_signal(cls, df: pd.DataFrame, extras: dict[str, pd.Series]):  # type: ignore
-        if len(df) < 21:
+        if len(df) < 200:
             return Signal("flat")
 
         high20 = df["High"].rolling(window=20).max()
         low20 = df["Low"].rolling(window=20).min()
         close = df["Close"]
+        sma200 = compute_sma(close, 200)
 
         last_close = close.iloc[-1]
         prev_close = close.iloc[-2]
 
         action = "flat"
-        if prev_close <= high20.iloc[-2] and last_close > high20.iloc[-1]:
+        if (
+            prev_close <= high20.iloc[-2]
+            and last_close > high20.iloc[-1]
+            and last_close > sma200.iloc[-1]
+        ):
             action = "long"
         elif prev_close >= low20.iloc[-2] and last_close < low20.iloc[-1]:
             action = "short"
@@ -37,5 +43,5 @@ class Donchian20(BaseStrategy):
         atr20 = extras.get("ATR_20")
         if atr20 is None:
             return Signal("flat")
-        stop_dist = 2.0 * float(atr20.iloc[-1])
+        stop_dist = 1.5 * float(atr20.iloc[-1])
         return Signal(action, stop_distance=stop_dist)


### PR DESCRIPTION
## Summary
- improve Donchian20 breakout strategy
  - require candle close above SMA200 for long trades
  - use stop distance of `1.5 * ATR20`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d87f58cc8329b70c1f41e5531304