### PR TITLE
Add RSI divergence detection

### DIFF
--- a/strategies/rsidivergence.py
+++ b/strategies/rsidivergence.py
@@ -12,16 +12,28 @@ class RSIDivergence(BaseStrategy):
 
     @classmethod
     def generate_signal(cls, df: pd.DataFrame, extras: dict[str, pd.Series]):  # type: ignore
-        if len(df) < 30:
+        if len(df) < 5:
             return Signal("flat")
+
         rsi = compute_rsi(df["Close"])
-        prev = rsi.iloc[-2]
-        curr = rsi.iloc[-1]
         action = "flat"
-        if prev < 30 <= curr:
-            action = "long"
-        elif prev > 70 >= curr:
-            action = "short"
+
+        # Use the last closed candle (-2) and one a few candles back (-4)
+        rsi_curr = rsi.iloc[-2]
+        rsi_prev = rsi.iloc[-4]
+        low_curr = df["Low"].iloc[-2]
+        low_prev = df["Low"].iloc[-4]
+        high_curr = df["High"].iloc[-2]
+        high_prev = df["High"].iloc[-4]
+
+        if rsi_curr < 30:
+            # Price makes a lower low but RSI a higher low -> bullish divergence
+            if low_curr < low_prev and rsi_curr > rsi_prev:
+                action = "long"
+            # Price makes a higher high but RSI a lower high -> bearish divergence
+            elif high_curr > high_prev and rsi_curr < rsi_prev:
+                action = "short"
+
         atr14 = extras.get("ATR_14")
         stop = None
         if atr14 is not None:


### PR DESCRIPTION
## Summary
- detect bullish/bearish RSI divergence using recent highs/lows
- keep using ATR14 for stop distance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d8809700832991f4010da0678df1