### PR TITLE
Pick strategy with widest stop distance when in consensus

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -303,11 +303,26 @@ class Engine:
 
         chosen = None
         if len(long_names) >= 3 and has_top(long_names):
-            chosen_sig = signals[long_names[0]]
-            chosen = ("long", long_names[0], chosen_sig)
+            # Pick strategy with widest stop distance for determinism
+            pick = max(
+                long_names,
+                key=lambda n: (
+                    signals[n].stop_distance or 0,
+                    n,
+                ),
+            )
+            chosen_sig = signals[pick]
+            chosen = ("long", pick, chosen_sig)
         elif len(short_names) >= 3 and has_top(short_names):
-            chosen_sig = signals[short_names[0]]
-            chosen = ("short", short_names[0], chosen_sig)
+            pick = max(
+                short_names,
+                key=lambda n: (
+                    signals[n].stop_distance or 0,
+                    n,
+                ),
+            )
+            chosen_sig = signals[pick]
+            chosen = ("short", pick, chosen_sig)
 
         if chosen:
             side, strat_name, ref_signal = chosen


### PR DESCRIPTION
## Summary
- choose the consensus strategy with the largest stop distance instead of the first match

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d888f2d483299977eea0e3d4440d