### PR TITLE
Add pytest config and comprehensive unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ pyyaml = "^6.0.1"
 [tool.poetry.dev-dependencies]
 pytest = "^8.0.0"
 
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]
+
 [build-system]
 requires = ["poetry-core>=1.5.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+import pandas as pd
+import numpy as np
+import pytest
+
+@pytest.fixture
+def sample_ohlcv():
+    index = pd.date_range("2021-01-01", periods=120, freq="H", tz="UTC")
+    close = pd.Series([100]*100 + [50]*18 + [300, 400], index=index)
+    df = pd.DataFrame({
+        "Open": close,
+        "High": close + 1,
+        "Low": close - 1,
+        "Close": close,
+        "Volume": np.random.randint(100, 200, size=len(close))
+    }, index=index)
+    return df
+
+@pytest.fixture
+def donchian_df():
+    index = pd.date_range("2021-02-01", periods=21, freq="H", tz="UTC")
+    high = pd.Series(list(range(1,21)) + [22], index=index)
+    low = high - 1
+    close = pd.Series(list(high[:-1] - 0.5) + [23], index=index)
+    df = pd.DataFrame({
+        "Open": low,
+        "High": high,
+        "Low": low,
+        "Close": close,
+        "Volume": np.random.randint(100, 200, size=len(close))
+    }, index=index)
+    return df

--- a/tests/test_engine_consensus.py
+++ b/tests/test_engine_consensus.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import types
+from core.engine import Engine, StrategyBase
+from core.utils import Signal
+
+class DummyExchange:
+    def load_markets(self):
+        pass
+    def fetch_balance(self):
+        return {"USDC": {"total": 1000}}
+    def fetch_ticker(self, symbol):
+        return {"quoteVolume": 1_000_000}
+    def create_order(self, symbol, order_type, side, amount):
+        return {"side": side, "amount": amount}
+
+class StratA(StrategyBase):
+    name = "EMA20_100"
+    @classmethod
+    def generate_signal(cls, df, extras):
+        return Signal("long", stop_distance=1)
+
+class StratB(StrategyBase):
+    name = "Donchian20"
+    @classmethod
+    def generate_signal(cls, df, extras):
+        return Signal("long", stop_distance=1)
+
+class StratC(StrategyBase):
+    name = "Other"
+    @classmethod
+    def generate_signal(cls, df, extras):
+        return Signal("long", stop_distance=1)
+
+
+def test_engine_consensus_long(sample_ohlcv, monkeypatch):
+    # patch ccxt factory
+    monkeypatch.setattr("ccxt.binance", lambda params=None: DummyExchange())
+    engine = Engine()
+    engine.register_strategy(StratA)
+    engine.register_strategy(StratB)
+    engine.register_strategy(StratC)
+
+    orders = []
+    def fake_send_order(self, symbol, side, amount, price, stop_distance, atr_value):
+        orders.append((side, amount))
+    monkeypatch.setattr(Engine, "_send_order", fake_send_order)
+    monkeypatch.setattr(engine.risk_manager, "allows_new_position", lambda *a, **k: (True, 1))
+
+    engine.run_once("BTC/USDC", df=sample_ohlcv)
+    assert orders and orders[0][0] == "long"

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.utils import compute_atr
+from strategies.ema20_100 import EMA20_100
+from strategies.donchian20 import Donchian20
+
+
+def test_ema20_100_long_signal(sample_ohlcv):
+    extras = {"ATR_20": compute_atr(sample_ohlcv, 20)}
+    signal = EMA20_100.generate_signal(sample_ohlcv, extras)
+    assert signal.action == "long"
+    assert signal.stop_distance is not None and signal.stop_distance > 0
+
+
+def test_donchian20_long_signal(donchian_df):
+    extras = {"ATR_20": compute_atr(donchian_df, 20)}
+    signal = Donchian20.generate_signal(donchian_df, extras)
+    assert signal.action == "long"
+    assert signal.stop_distance is not None and signal.stop_distance > 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+import numpy as np
+from core.utils import (
+    compute_ema,
+    compute_true_range,
+    compute_atr,
+    compute_macd,
+)
+
+
+def test_compute_ema():
+    series = pd.Series([1, 2, 3, 4, 5])
+    result = compute_ema(series, 3)
+    expected = series.ewm(span=3, adjust=False).mean()
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_true_range_and_atr(sample_ohlcv):
+    tr = compute_true_range(sample_ohlcv)
+    expected_tr = pd.concat([
+        sample_ohlcv['High'] - sample_ohlcv['Low'],
+        (sample_ohlcv['High'] - sample_ohlcv['Close'].shift(1)).abs(),
+        (sample_ohlcv['Low'] - sample_ohlcv['Close'].shift(1)).abs(),
+    ], axis=1).max(axis=1)
+    pd.testing.assert_series_equal(tr, expected_tr)
+
+    atr = compute_atr(sample_ohlcv, 14)
+    expected_atr = expected_tr.rolling(window=14, min_periods=1).mean()
+    pd.testing.assert_series_equal(atr, expected_atr)
+
+
+def test_compute_macd():
+    series = pd.Series(np.linspace(1, 10, 50))
+    macd, signal, hist = compute_macd(series)
+    ema_fast = series.ewm(span=12, adjust=False).mean()
+    ema_slow = series.ewm(span=26, adjust=False).mean()
+    exp_macd = ema_fast - ema_slow
+    exp_signal = exp_macd.ewm(span=9, adjust=False).mean()
+    pd.testing.assert_series_equal(macd, exp_macd)
+    pd.testing.assert_series_equal(signal, exp_signal)
+    pd.testing.assert_series_equal(hist, exp_macd - exp_signal)


### PR DESCRIPTION
## Summary
- configure pytest in `pyproject.toml`
- add fixtures for OHLCV data
- test indicator utilities
- test strategy signal generation
- test engine consensus logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d8988c80832986209dd9d3a30a4b