### PR TITLE
Remove redundant CLI runner

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -422,25 +422,3 @@ class Engine:
             self._save_positions()
 
 
-if __name__ == "__main__":  # pragma: no cover
-    import argparse
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--pair", required=True, help="Symbol pair like BTC/USDC")
-    parser.add_argument("--once", action="store_true", help="Run once and exit")
-    args = parser.parse_args()
-
-    eng = Engine()
-    # TODO: register strategy classes
-    # from strategies.ema20_100 import EMA20_100
-    # eng.register_strategy(EMA20_100)
-
-    if args.once:
-        eng.run_once(args.pair)
-    else:
-        # Simplistic loop every 4h
-        while True:
-            now = datetime.now(timezone.utc)
-            if now.hour % 4 == 0 and now.minute < 2:
-                eng.run_once(args.pair)
-            time.sleep(60)


### PR DESCRIPTION
## Summary
- cut out direct CLI code from `Engine`

## Testing
- `pytest -q` *(fails: test_engine_consensus_long, test_ema20_100_long_signal, test_donchian20_long_signal)*

------
https://chatgpt.com/codex/tasks/task_e_6876412402908329b00d5c2863c438f2