### PR TITLE
Fix strategy test data for long signals

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,9 @@ import pytest
 @pytest.fixture
 def sample_ohlcv():
     index = pd.date_range("2021-01-01", periods=120, freq="H", tz="UTC")
-    close = pd.Series([100]*100 + [50]*18 + [300, 400], index=index)
+    # Use a strong rally on the last three candles so EMA20 slope is
+    # positive and crosses above EMA100
+    close = pd.Series([100]*100 + [50]*17 + [60, 300, 400], index=index)
     df = pd.DataFrame({
         "Open": close,
         "High": close + 1,
@@ -17,10 +19,14 @@ def sample_ohlcv():
 
 @pytest.fixture
 def donchian_df():
-    index = pd.date_range("2021-02-01", periods=21, freq="H", tz="UTC")
-    high = pd.Series(list(range(1,21)) + [22], index=index)
+    # At least 200 candles so Donchian20 can produce a valid signal. We
+    # create a simple upward trend where the last close breaks above the
+    # 20-period high and is also above the SMA200.
+    index = pd.date_range("2021-02-01", periods=201, freq="H", tz="UTC")
+    high = pd.Series(range(1, 202), index=index)
     low = high - 1
-    close = pd.Series(list(high[:-1] - 0.5) + [23], index=index)
+    close = pd.Series(high - 0.5, index=index)
+    close.iloc[-1] = high.iloc[-1] + 1  # breakout on the last candle
     df = pd.DataFrame({
         "Open": low,
         "High": high,

--- a/tests/test_engine_consensus.py
+++ b/tests/test_engine_consensus.py
@@ -45,7 +45,7 @@ def test_engine_consensus_long(sample_ohlcv, monkeypatch):
     engine.register_strategy(StratC)
 
     orders = []
-    def fake_send_order(self, symbol, side, amount, price, stop_distance, atr_value):
+    def fake_send_order(self, symbol, side, amount, price, stop_distance, atr_value, trailing_mode=None, strategy=None):
         orders.append((side, amount))
     monkeypatch.setattr(Engine, "_send_order", fake_send_order)
     monkeypatch.setattr(engine.risk_manager, "allows_new_position", lambda *a, **k: (True, 1))


### PR DESCRIPTION
## Summary
- ensure EMA20_100 sample candles rally so last crossover is bullish
- expand Donchian20 fixture to 201 bars for valid signal
- update consensus test helper to accept new `_send_order` arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68764122e18483298b91f2a4748085da