### PR TITLE
Fix consensus test for updated send_order signature

### DIFF
--- a/tests/test_engine_consensus.py
+++ b/tests/test_engine_consensus.py
@@ -45,7 +45,17 @@ def test_engine_consensus_long(sample_ohlcv, monkeypatch):
     engine.register_strategy(StratC)
 
     orders = []
-    def fake_send_order(self, symbol, side, amount, price, stop_distance, atr_value):
+    def fake_send_order(
+        self,
+        symbol,
+        side,
+        amount,
+        price,
+        stop_distance,
+        atr_value,
+        trailing_mode,
+        strategy,
+    ):
         orders.append((side, amount))
     monkeypatch.setattr(Engine, "_send_order", fake_send_order)
     monkeypatch.setattr(engine.risk_manager, "allows_new_position", lambda *a, **k: (True, 1))


### PR DESCRIPTION
## Summary
- adapt `fake_send_order` in engine consensus test to new `_send_order` parameters

## Testing
- `pytest tests/test_engine_consensus.py::test_engine_consensus_long -q`

------
https://chatgpt.com/codex/tasks/task_e_68764122cfc0832995703344ae852e87