### PR TITLE
Implement CLI & trailing stop tests

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,80 @@
+"""Command line interface for Sentinel Crypto Agent."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from datetime import datetime, timezone
+import time
+import pandas as pd
+
+from core.engine import Engine
+from strategies import (
+    EMA20_100,
+    Donchian20,
+    BollingerSqueeze,
+    IchimokuKumo,
+    MACDZeroCross,
+    VWAPPullback,
+    KeltnerUpperRide,
+    SMA50Pullback,
+    SARFlip,
+    RSIDivergence,
+)
+
+
+def _register_all(eng: Engine) -> Engine:
+    eng.register_strategy(EMA20_100)
+    eng.register_strategy(Donchian20)
+    eng.register_strategy(BollingerSqueeze)
+    eng.register_strategy(IchimokuKumo)
+    eng.register_strategy(MACDZeroCross)
+    eng.register_strategy(VWAPPullback)
+    eng.register_strategy(KeltnerUpperRide)
+    eng.register_strategy(SMA50Pullback)
+    eng.register_strategy(SARFlip)
+    eng.register_strategy(RSIDivergence)
+    return eng
+
+
+def cmd_backtest(args: argparse.Namespace) -> None:
+    eng = _register_all(Engine(paper=True))
+    df = eng.fetch_ohlcv(args.pair, limit=2000)
+    df = df[df.index >= pd.Timestamp("2020-01-01", tz="UTC")]
+    for i in range(len(df)):
+        eng.run_once(args.pair, df=df.iloc[: i + 1])
+    kpi = eng.export_csv(Path("trades.csv"))
+    print(f"CAGR: {kpi['CAGR']:.2%}  MDD: {kpi['MDD']:.2%}")
+
+
+def cmd_live(args: argparse.Namespace) -> None:
+    eng = _register_all(Engine(paper=args.paper))
+    print("[Sentinel] Running live mode. Evaluating every 4H close UTC…")
+    while True:
+        now = datetime.now(timezone.utc)
+        if now.hour % 4 == 0 and now.minute < 3:
+            eng.run_once(args.pair)
+            time.sleep(60 * 180)
+        else:
+            time.sleep(60)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sentinel CLI")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_back = sub.add_parser("backtest", help="Run backtest from 2020")
+    p_back.add_argument("--pair", default="BTC/USDC")
+
+    p_live = sub.add_parser("live", help="Run live mode")
+    p_live.add_argument("--pair", default="BTC/USDC")
+    p_live.add_argument("--paper", action="store_true", help="Simulated orders")
+
+    args = parser.parse_args()
+    if args.cmd == "backtest":
+        cmd_backtest(args)
+    elif args.cmd == "live":
+        cmd_live(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_trailing.py
+++ b/tests/test_trailing.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+from core.engine import Engine
+
+
+def _dummy_exchange():
+    class Ex:
+        def load_markets(self):
+            pass
+        def fetch_balance(self):
+            return {"USDC": {"total": 1000}}
+        def fetch_ticker(self, symbol):
+            return {"quoteVolume": 1_000_000}
+        def create_order(self, symbol, order_type, side, amount):
+            return {"side": side, "amount": amount}
+    return Ex()
+
+
+def test_trailing_stop_never_decreases_long(monkeypatch):
+    monkeypatch.setattr("ccxt.binance", lambda params=None: _dummy_exchange())
+    eng = Engine(paper=True)
+    df = pd.DataFrame(
+        {
+            "Open": [1, 2, 3],
+            "High": [1.5, 2.5, 2.0],
+            "Low": [0.5, 1.5, 1.0],
+            "Close": [1, 2, 1.8],
+            "Volume": [1, 1, 1],
+        },
+        index=pd.date_range("2024-01-01", periods=3, freq="4H", tz="UTC"),
+    )
+    eng.positions = [
+        {
+            "time": str(df.index[-2]),
+            "symbol": "BTC/USDC",
+            "side": "long",
+            "amount": 1.0,
+            "price": 2.0,
+            "order": {},
+            "status": "open",
+            "stop_price": 1.0,
+            "atr_multiplier": 2.0,
+            "armed": True,
+            "trail_mode": "atr",
+            "strategy": "test",
+            "stop_pct": 50.0,
+            "signal_source": "test",
+        }
+    ]
+    extras = {"ATR_20": pd.Series([1, 1, 1], index=df.index)}
+    eng._update_open_positions(df, extras)
+    assert eng.positions[0]["stop_price"] >= 1.0
+
+
+def test_trailing_stop_never_increases_short(monkeypatch):
+    monkeypatch.setattr("ccxt.binance", lambda params=None: _dummy_exchange())
+    eng = Engine(paper=True)
+    df = pd.DataFrame(
+        {
+            "Open": [3, 2, 1],
+            "High": [3.5, 2.5, 1.5],
+            "Low": [2.5, 1.5, 0.5],
+            "Close": [3, 2, 1.2],
+            "Volume": [1, 1, 1],
+        },
+        index=pd.date_range("2024-01-01", periods=3, freq="4H", tz="UTC"),
+    )
+    eng.positions = [
+        {
+            "time": str(df.index[-2]),
+            "symbol": "BTC/USDC",
+            "side": "short",
+            "amount": 1.0,
+            "price": 2.0,
+            "order": {},
+            "status": "open",
+            "stop_price": 3.0,
+            "atr_multiplier": 2.0,
+            "armed": True,
+            "trail_mode": "atr",
+            "strategy": "test",
+            "stop_pct": 50.0,
+            "signal_source": "test",
+        }
+    ]
+    extras = {"ATR_20": pd.Series([1, 1, 1], index=df.index)}
+    eng._update_open_positions(df, extras)
+    assert eng.positions[0]["stop_price"] <= 3.0


### PR DESCRIPTION
## Summary
- add CLI with backtest and live commands
- support paper mode and additional logging fields
- ensure stop never moves backward with new unit tests
- export trades to CSV with CAGR and MDD KPI computation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687663b39d40832982c983934501322f