### PR TITLE
Fix imports for pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
+import site
+from pathlib import Path
 import pandas as pd
 import numpy as np
 import pytest
+
+# Ensure project root is on the Python path for imports
+site.addsitedir(str(Path(__file__).resolve().parents[1]))
 
 @pytest.fixture
 def sample_ohlcv():

--- a/tests/test_engine_consensus.py
+++ b/tests/test_engine_consensus.py
@@ -1,8 +1,3 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 import types
 from core.engine import Engine, StrategyBase
 from core.utils import Signal

--- a/tests/test_macdzerocross.py
+++ b/tests/test_macdzerocross.py
@@ -1,8 +1,3 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 import pandas as pd
 import strategies.macdzerocross as macdzerocross
 

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,8 +1,4 @@
 from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from core.risk_manager import RiskManager
 
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,8 +1,3 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from core.utils import compute_atr
 from strategies.ema20_100 import EMA20_100
 from strategies.donchian20 import Donchian20

--- a/tests/test_trailing.py
+++ b/tests/test_trailing.py
@@ -1,7 +1,3 @@
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 import pandas as pd
 from core.engine import Engine
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,3 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 import pandas as pd
 import numpy as np
 from core.utils import (


### PR DESCRIPTION
## Summary
- configure central PYTHONPATH in test suite
- remove ad-hoc `sys.path` hacks from tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68791e2a05a0832983ccac87570ac293