### PR TITLE
Add requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pandas==2.2.0
+numpy==1.26.0
+ccxt==4.2.0
+TA-Lib[binary]==0.4.28
+scipy==1.11.0
+pyyaml==6.0.1


### PR DESCRIPTION
## Summary
- add `requirements.txt` to pin runtime dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68791e2584508329839579151507e6e0