### PR TITLE
Remove unused variable in risk manager

### DIFF
--- a/core/risk_manager.py
+++ b/core/risk_manager.py
@@ -132,7 +132,6 @@ class RiskManager:
     ) -> Tuple[bool, float]:
         """Return (allowed, size) for a new position."""
         amount = self.risk_per_trade(stop_distance)
-        new_value = amount * stop_distance
         if not self.exposure_ok(open_value, price * amount):
             self.log_event(f"Exposure cap block on {symbol}")
             return False, 0.0


### PR DESCRIPTION
## Summary
- remove unused `new_value` calculation in RiskManager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68791e1953b4832981e238a64bb531dc