### PR TITLE
Fix frequency strings in test helpers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ site.addsitedir(str(Path(__file__).resolve().parents[1]))
 
 @pytest.fixture
 def sample_ohlcv():
-    index = pd.date_range("2021-01-01", periods=120, freq="H", tz="UTC")
+    index = pd.date_range("2021-01-01", periods=120, freq="h", tz="UTC")
     # Use a strong rally on the last three candles so EMA20 slope is
     # positive and crosses above EMA100
     close = pd.Series([100]*100 + [50]*17 + [60, 300, 400], index=index)
@@ -27,7 +27,7 @@ def donchian_df():
     # At least 200 candles so Donchian20 can produce a valid signal. We
     # create a simple upward trend where the last close breaks above the
     # 20-period high and is also above the SMA200.
-    index = pd.date_range("2021-02-01", periods=201, freq="H", tz="UTC")
+    index = pd.date_range("2021-02-01", periods=201, freq="h", tz="UTC")
     high = pd.Series(range(1, 202), index=index)
     low = high - 1
     close = pd.Series(high - 0.5, index=index)

--- a/tests/test_sarflip.py
+++ b/tests/test_sarflip.py
@@ -6,7 +6,7 @@ from core.utils import compute_psar
 
 
 def _make_df(volumes):
-    idx = pd.date_range("2024-01-01", periods=len(volumes), freq="4H")
+    idx = pd.date_range("2024-01-01", periods=len(volumes), freq="4h")
     data = {
         "Open": np.arange(len(volumes), dtype=float),
         "High": np.arange(len(volumes), dtype=float) + 1,

--- a/tests/test_trailing.py
+++ b/tests/test_trailing.py
@@ -26,7 +26,7 @@ def test_trailing_stop_never_decreases_long(monkeypatch):
             "Close": [1, 2, 1.8],
             "Volume": [1, 1, 1],
         },
-        index=pd.date_range("2024-01-01", periods=3, freq="4H", tz="UTC"),
+        index=pd.date_range("2024-01-01", periods=3, freq="4h", tz="UTC"),
     )
     eng.positions = [
         {
@@ -62,7 +62,7 @@ def test_trailing_stop_never_increases_short(monkeypatch):
             "Close": [3, 2, 1.2],
             "Volume": [1, 1, 1],
         },
-        index=pd.date_range("2024-01-01", periods=3, freq="4H", tz="UTC"),
+        index=pd.date_range("2024-01-01", periods=3, freq="4h", tz="UTC"),
     )
     eng.positions = [
         {


### PR DESCRIPTION
## Summary
- use lowercase hourly frequency strings
- prevent Pandas `H` deprecation warnings in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b4b74b0948329ae1489b81f6fe8bc