### PR TITLE
Update ccxt constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 python = "^3.11"
 pandas = "^2.2.0"
 numpy = "^1.26.0"
-ccxt = "^4.2.0"
+ccxt = ">=4.2.1"
 TA-Lib = {version = "^0.4.28", extras = ["binary"]}
 scipy = "^1.11.0"
 pyyaml = "^6.0.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandas==2.2.0
 numpy==1.26.0
-ccxt==4.2.0
+ccxt>=4.2.1
 TA-Lib[binary]==0.4.28
 scipy==1.11.0
 pyyaml==6.0.1


### PR DESCRIPTION
## Summary
- fix ccxt version constraints in `requirements.txt` and `pyproject.toml`

## Testing
- `pip install -r requirements.txt` *(fails: `scipy` build error)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687b4b742a0883298a04a6e97acb222d